### PR TITLE
Fixed Get-AzServiceBusQueue call to use NameSpaceName according to do…

### DIFF
--- a/MarkAndDeleteUnusedResources.ps1
+++ b/MarkAndDeleteUnusedResources.ps1
@@ -628,7 +628,7 @@ function Test-ResourceActionHook-microsoft-operationalinsights-workspaces($Resou
     return [ResourceAction]::none, ""
 }
 function Test-ResourceActionHook-microsoft-servicebus-namespaces($Resource) {
-    $queues = Get-AzServiceBusQueue -ResourceGroupName $Resource.resourceGroup -Namespace $Resource.name
+    $queues = Get-AzServiceBusQueue -ResourceGroupName $Resource.resourceGroup -NamespaceName $Resource.name
     $result = [ResourceAction]::none
     foreach ($queue in $queues) {
         if ($queue.Status -ine "Active") {


### PR DESCRIPTION
Got an error on line 631:

Processing resource 'xxxxx' (type: microsoft.servicebus/namespaces, resource group: xxxxx)...
Get-AzServiceBusQueue: C:\Repository\AzSaveMoney\MarkAndDeleteUnusedResources.ps1:631
Line |
 631 |  … usQueue -ResourceGroupName $Resource.resourceGroup -Namespace $Resour …
     |                                                       ~~~~~~~~~~
     | Parameter cannot be processed because the parameter name 'Namespace' is ambiguous. Possible matches include:
     | -NamespaceName -NamespaceInputObject.
        --> action: none
    Processing resource 'xxxxx' (type: microsoft.servicebus/namespaces, resource group: xxxxxx)...


Changed to NameSpaceName according to documentation: https://learn.microsoft.com/en-us/powershell/module/az.servicebus/get-azservicebusqueue?view=azps-12.1.0